### PR TITLE
메뉴에 course3 추가

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -18,7 +18,7 @@ navbar-links:
   Courses:
     - course 1. git/github: "/2021-07-22-course1-git-and-github"
     - course 2. about NLP: "/2021-07-23-course2-about-nlp"
-    # - course 3. NLP Tools: "https://beautifuljekyll.com"    
+    - course 3. NLP Tools: "https://beautifuljekyll.com"    
 Author's home: "https://deanattali.com"
 
 # --- Logo --- #

--- a/_config.yml
+++ b/_config.yml
@@ -18,7 +18,7 @@ navbar-links:
   Courses:
     - course 1. git/github: "/2021-07-22-course1-git-and-github"
     - course 2. about NLP: "/2021-07-23-course2-about-nlp"
-    - course 3. NLP Tools: "https://beautifuljekyll.com"    
+    - course 3. NLP Tools: "/2021-08-05-course3-korean-nlp-tools/"    
 Author's home: "https://deanattali.com"
 
 # --- Logo --- #


### PR DESCRIPTION
`config.yml`에서 주석 처리된 부분을 수정하여 블로그 메뉴 카테고리에서 없어진 course3를 복구했습니다 :)